### PR TITLE
Fix Error JSON_DATA_TEXT in souffle-compile.py on Apple Silicon

### DIFF
--- a/Formula/souffle.rb
+++ b/Formula/souffle.rb
@@ -20,7 +20,20 @@ class Souffle < Formula
     end
 
     system "cmake", "-B", "build", "-S", ".", "-DCMAKE_INSTALL_PREFIX=#{prefix}","-DSOUFFLE_GIT=OFF", "-DSOUFFLE_BASH_COMPLETION=OFF", "-DCMAKE_C_COMPILER=gcc-11", "-DCMAKE_CXX_COMPILER=g++-11"
+    
+    on_macos do
+      on_arm do
+        system "cmake", "-B", "build", "-S", ".", "-DCMAKE_INSTALL_PREFIX=#{prefix}","-DSOUFFLE_GIT=OFF", "-DSOUFFLE_BASH_COMPLETION=OFF", "-DCMAKE_C_COMPILER=gcc", "-DCMAKE_CXX_COMPILER=g++", "-DCMAKE_CXX_FLAGS=-I#{include}"
+      end
+    end
+
     system "cmake", "--build", "build", "--target", "install", "-j17"
+
+    on_macos do
+      on_arm do
+        system "sed", "-i", ".bak", "s\##{HOMEBREW_PREFIX}/Library/Homebrew/shims/mac/super/g++#/usr/bin/g++#g", "#{bin}/souffle-compile.py"
+      end
+    end
   end
 
   test do


### PR DESCRIPTION
## Detail of the error on m1/m2 serials mac os.

While install with the command on mac os with applie silicon chips.

```
brew install --HEAD souffle-lang/souffle/souffle
```

The generated souffle-compile.py file has an invalid JSON_DATA_TEXT configuration as show below.

```
#!/usr/bin/env python3
JSON_DATA_TEXT = """{
  "compiler": "/opt/homebrew/Library/Homebrew/shims/mac/super/g++-11",
  "compiler_id": "AppleClang",
  "compiler_version": "14.0.0.14000029",
  "msvc_version": "",
  "includes": "-I/tmp/souffle-20221019-29532-1c32bqh/src/include -I/Library/Frameworks/Mono.framework/Headers",
  "std_flag": "-std=c++17",
  "cxx_flags": "",
  "cxx_link_flags": "-Wl,-search_paths_first -Wl,-headerpad_max_install_names",
  "release_cxx_flags": "-O3 ",
  "debug_cxx_flags": "-g",
  "definitions": "-DUSE_NCURSES -DUSE_LIBZ -DUSE_SQLITE",
  "compile_options": "",
  "link_options": "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/lib/libsqlite3.tbd /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/lib/libz.tbd /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/lib/libncurses.tbd",
  "rpaths": "/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/lib:/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/lib:/Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk/usr/lib",
  "outname_fmt": "-o {}",
  "libdir_fmt": "-L{}",
  "libname_fmt": "-l{}",
  "rpath_fmt": "-Wl,-rpath,{}",
  "path_delimiter": ":",
  "exe_extension": "",
  "source_include_dir": "/tmp/souffle-20221019-29532-1c32bqh/src/include",
  "jni_includes": ":"
}"""

# --- JSON_DATA_TEXT variable is inserted before this line ---
```

There has two problem, 
* the `/opt/homebrew/Library/Homebrew/shims/mac/super/g++-11` of homebrew cannot be use directly, otherwise an error info [g++-11: The build tool has reset ENV; --env=std required.](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/shims/super/cc) will be throws.
* the include directory `/tmp/souffle-20221019-29532-1c32bqh/src/include` was a temporary directory, it will be deleted after installation.

Theres problem will leading to the `souffle -o` failed, because compile failed. For more detail of this issue see [souffle-lang/souffle/issues/2325](https://github.com/souffle-lang/souffle/issues/2325).
