### PR TITLE
Updated formula for Souffle 2.4 and MacOS 14

### DIFF
--- a/Formula/souffle.rb
+++ b/Formula/souffle.rb
@@ -3,7 +3,7 @@ class Souffle < Formula
   homepage "https://souffle-lang.github.io"
 
   stable do
-    url "https://github.com/souffle-lang/souffle", :using => :git, :tag => "2.3", :shallow => false
+    url "https://github.com/souffle-lang/souffle", :using => :git, :tag => "2.4", :shallow => false
   end
 
   head "https://github.com/souffle-lang/souffle.git", :shallow => false
@@ -38,7 +38,7 @@ class Souffle < Formula
   test do
     assert_equal <<-EOS, shell_output("#{bin}/souffle --version 2>&1")
 ----------------------------------------------------------------------------
-Version: 2.3
+Version: 2.4
 ----------------------------------------------------------------------------
 Copyright (c) 2016-22 The Souffle Developers.
 Copyright (c) 2013-16 Oracle and/or its affiliates.


### PR DESCRIPTION
Sample output from `brew reinstall -d -v --build-from-source ./souffle.rb`

```
==> Fetching souffle
==> Cloning https://github.com/souffle-lang/souffle
...
==> Checking out tag 2.4
/usr/bin/env git checkout -f 2.4 --
HEAD is now at b60c8e9f3 Update changelog (#2397)
/usr/bin/env git reset --hard 2.4 --
HEAD is now at b60c8e9f3 Update changelog (#2397)
==> Reinstalling souffle
...
==> cmake -B build -S . -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/souffle/2.4 -DSOUFFLE_BASH_COMPLETION=OFF -DCMAKE_CXX_COMPILER=g++-11
-- Found Git: /usr/local/bin/git (found version "2.39.2")
-- Building souffle version 2.4
-- The CXX compiler identification is AppleClang 15.0.0.15000100
...
==> cmake --build build --target install -j
[  1%] [FLEX][scanner] Building scanner with flex 2.6.4
[  1%] [BISON][parser] Building parser with bison 3.8.2
...
Install the project...
-- Install configuration: "Release"
-- Installing: /usr/local/Cellar/souffle/2.4/include/souffle
...
==> Cleaning
==> Fixing /usr/local/opt/souffle/bin/souffle permissions from 755 to 555
==> Fixing /usr/local/opt/souffle/bin/souffle-compile.py permissions from 755 to 555
==> Fixing /usr/local/opt/souffle/bin/souffleprof permissions from 755 to 555
==> Finishing up
ln -s ../Cellar/souffle/2.4/bin/souffle souffle
ln -s ../Cellar/souffle/2.4/bin/souffle-compile.py souffle-compile.py
ln -s ../Cellar/souffle/2.4/bin/souffleprof souffleprof
ln -s ../Cellar/souffle/2.4/include/souffle souffle
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaAPILoader): loading llvm@14 from API
==> Summary
🍺  /usr/local/Cellar/souffle/2.4: 104 files, 18.5MB, built in 4 minutes 26 seconds
```
